### PR TITLE
Add decorator for checking function argument types.

### DIFF
--- a/runtime_typecheck/runtime_typecheck.py
+++ b/runtime_typecheck/runtime_typecheck.py
@@ -5,6 +5,7 @@ from typing import (Union,
                     TypeVar,
                     Type,
                     List)
+import inspect
 
 
 def check_type(obj, candidate_type, reltype='invariant') -> bool:
@@ -55,3 +56,14 @@ def check_type(obj, candidate_type, reltype='invariant') -> bool:
         return check_type(obj, candidate_type.__args__[0], reltype='covariant')
 
     raise ValueError(f'Cannot check against {reltype} type {candidate_type}')
+
+
+def check_args(func):
+    def check(*args):
+        sig = inspect.signature(func)
+        params = zip(sig.parameters, args)
+        for name, value in params:
+            if not check_type(value, sig.parameters[name].annotation):
+                raise TypeError(f'Expected {sig.parameters[name]}, got {type(value)}.')
+        return func(*args)
+    return check

--- a/tests/test_runtime_typecheck.py
+++ b/tests/test_runtime_typecheck.py
@@ -1,6 +1,8 @@
-from typing import Union, Tuple, Any, TypeVar, Type, List
+from typing import Union, Tuple, Any, List
 
-from runtime_typecheck.runtime_typecheck import check_type
+import pytest
+
+from runtime_typecheck.runtime_typecheck import check_type, check_args
 
 
 def test_any():
@@ -40,3 +42,22 @@ def test_nested_types():
     assert not check_type([(1.9, "Texas"), (-5, "Particle")],
                           List[Tuple[int, str]])
     assert not check_type([1.11, 27, 33, 1956], List[Tuple[int, str]])
+
+
+@check_args
+def dummy_fun(a: int = 0, b: str = '', c: Tuple[int, str] = (0, '')) -> int:
+    return 1
+
+
+def test_args():
+    assert dummy_fun() == 1
+    assert dummy_fun(10, 'antani', (1, '0')) == 1
+
+
+def test_raises():
+    with pytest.raises(TypeError):
+        dummy_fun('1')
+    with pytest.raises(TypeError):
+        dummy_fun(1, 1)
+    with pytest.raises(TypeError):
+        dummy_fun(1, '1', ('1', '0'))


### PR DESCRIPTION
- Uses `inspect.signature` to get function params info
- Throws `TypeError` if type mismatch
- Only works with "unnamed" args at the moment
- Remove unused `import`s