### PR TITLE
Add named argument support

### DIFF
--- a/runtime_typecheck/runtime_typecheck.py
+++ b/runtime_typecheck/runtime_typecheck.py
@@ -99,15 +99,15 @@ def check_args(func):
     """
 
     @wraps(func)
-    def check(*args):
+    def check(*args, **kwargs):
         sig = inspect.signature(func)
-        params = zip(sig.parameters, args)
+        binding = sig.bind(*args, **kwargs)
         found_errors = []
-        for name, value in params:
+        for name, value in binding.arguments.items():
             if not check_type(value, sig.parameters[name].annotation):
                 found_errors.append(IssueDescription(name, sig.parameters[name].annotation, value))
         if len(found_errors) > 0:
             raise DetailedTypeError(found_errors)
-        return func(*args)
+        return func(*args, **kwargs)
 
     return check

--- a/tests/test_runtime_typecheck.py
+++ b/tests/test_runtime_typecheck.py
@@ -52,6 +52,8 @@ def dummy_fun(a: int = 0, b: str = '', c: Tuple[int, str] = (0, '')) -> int:
 def test_args():
     assert dummy_fun() == 7
     assert dummy_fun(10, 'antani', (1, '0')) == 25
+    assert dummy_fun(a=10, b='antani', c=(1, '0')) == 25
+
 
 def test_raises():
     with pytest.raises(DetailedTypeError):
@@ -62,3 +64,5 @@ def test_raises():
         dummy_fun(1, '1', ('1', '0'))
     with pytest.raises(TypeError):
         dummy_fun(1, '1', (1, '0'), extra=42)
+    with pytest.raises(DetailedTypeError):
+        dummy_fun(a=1, b='1', c=('1', '0'))


### PR DESCRIPTION
`Signature.bind` allows to handle `**kwargs` and offers better APIs
to access parameter name and value. From the `bind` we can still
access the original `signature` and get the `annotation`